### PR TITLE
elasticsearch connection only worked in the simple case where 'localh…

### DIFF
--- a/connector/elasticsearch/elasticsearch/elasticsearch.py
+++ b/connector/elasticsearch/elasticsearch/elasticsearch.py
@@ -22,6 +22,7 @@ Saves content to an ElasticSearch index
 import time
 import threading
 import traceback
+import certifi
 
 from datetime import datetime
 from elasticsearch import Elasticsearch
@@ -193,6 +194,10 @@ class ElasticSearchConnector(StoqConnectorPlugin):
         Connect to an elasticsearch instance
 
         """
-        self.es = Elasticsearch(self.conn, timeout=self.es_timeout,
+        self.es = Elasticsearch(self.connect_host_list,
+                                timeout=self.es_timeout,
                                 max_retries=self.es_max_retries,
-                                retry_on_timeout=self.es_retry)
+                                retry_on_timeout=self.es_retry,
+                                ca_certs=certifi.where(),
+                                **self.connect_opts_dict
+                                )

--- a/connector/elasticsearch/elasticsearch/elasticsearch.stoq
+++ b/connector/elasticsearch/elasticsearch/elasticsearch.stoq
@@ -29,19 +29,18 @@ Description = Saves content to an ElasticSearch index
 #       http://elasticsearch-py.readthedocs.org/en/latest/api.html
 #
 # Examples:
-# create connection to localhost using the ThriftConnection and it's
-# default port (9500)
-# conn = connection_class=ThriftConnection
 #
 # create connection that will automatically inspect the cluster to get
 # the list of active nodes. Start with nodes 'esnode1' and 'esnode2'
-# conn =  ['esnode1', 'esnode2'], sniff_on_start=True, sniff_on_connection_fail=True, sniffer_timeout=60
+# connect_host_list = [esnode1, esnode2]
+# connect_opts_dict = {"sniff_on_start": true, "sniff_on_connection_fail": true, "sniffer_timeout": 60}
 #
-# connect to localhost directly and another node using SSL on port 443
-# and an url_prefix
-# conn = [{'host': 'localhost'}, {'host': 'othernode', 'port': 443, 'url_prefix': 'es', 'use_ssl': True}, ]
+# connect to a node using SSL on port 443
+# connect_host_list = [localhost]
+# connect_opts_dict = {"port": 443, "use_ssl": true, "verify_certs": true}
 
-conn = 127.0.0.1:9200
+connect_host_list = [localhost]
+connect_opts_dict = {"port": 9200}
 
 # How long should we wait for ES operations before it times out?
 es_timeout = 60


### PR DESCRIPTION
…ost:9200' was passed as a string, but didn't work for other use cases.

Separate passing a list of hosts and connection options, in line with the way the elasticsearch driver actually works