### PR TITLE
Playbook option needed to be set

### DIFF
--- a/worker/threatgrid/threatgrid/threatgrid.py
+++ b/worker/threatgrid/threatgrid/threatgrid.py
@@ -61,7 +61,7 @@ class ThreatGridWorker(StoqWorkerPlugin):
                                  default=[],
                                  help="Tags applied to samples")
         worker_opts.add_argument("--playbook",
-                                 dest='tags',
+                                 dest='playbook',
                                  default='none',
                                  help="Name of playbook to apply to sample run")
         worker_opts.add_argument("--network_exit",


### PR DESCRIPTION
the argument for playbook was populating a tags variable and not the playbook variable and was throwing the following error

` stoq.worker.threatgrid: {'archive': 'file', 'err': "'ThreatGridWorker' object has no attribute 'playbook'", 'ratelimit': None, 'path': 'dispatcher.yar'}
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/stoq-0.21.0-py3.5.egg/stoq/plugins.py", line 721, in _multiprocess
    self.start(**msg)
  File "/usr/local/lib/python3.5/dist-packages/stoq-0.21.0-py3.5.egg/stoq/helpers.py", line 82, in ratelimit
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.5/dist-packages/stoq-0.21.0-py3.5.egg/stoq/plugins.py", line 1027, in start
    scan_results = self.scan(payload, **kwargs)
  File "/usr/local/stoq/plugins/worker/threatgrid/threatgrid.py", line 100, in scan
    playbook=self.playbook,
AttributeError: 'ThreatGridWorker' object has no attribute 'playbook'`