### PR TITLE
Use core email library

### DIFF
--- a/smtp/requirements.txt
+++ b/smtp/requirements.txt
@@ -1,2 +1,0 @@
-pyzmail36>=1.0.3
-beautifulsoup4~=4.6.3

--- a/smtp/setup.py
+++ b/smtp/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="smtp",
-    version="2.0.2",
+    version="2.0.3",
     author="Marcus LaFerrera (@mlaferrera)",
     url="https://github.com/PUNCH-Cyber/stoq-plugins-public/v2",
     license="Apache License 2.0",

--- a/smtp/smtp/smtp.py
+++ b/smtp/smtp/smtp.py
@@ -22,7 +22,8 @@ Parse SMTP sessions
 """
 
 from email import policy
-from email.parser import BytesParser
+from bs4 import UnicodeDammit
+from email.parser import Parser
 from configparser import ConfigParser
 from typing import List, Dict, Optional
 
@@ -92,7 +93,8 @@ class SMTPPlugin(WorkerPlugin):
         attachments: List[ExtractedPayload] = []
         errors: List[str] = []
         ioc_content: str = ''
-        message = BytesParser(policy=policy.default).parsebytes(payload.content)
+        session = UnicodeDammit(payload.content).unicode_markup
+        message = Parser(policy=policy.default).parsestr(session)
 
         # Create a dict of the SMTP headers
         for header, value in message.items():
@@ -130,7 +132,7 @@ class SMTPPlugin(WorkerPlugin):
                         attachment = ExtractedPayload(part.as_bytes(), attachment_meta)
                         attachments.append(attachment)
                     except Exception as err:
-                        errors.append(f'Failed extracting attachment: {err}')
+                        errors.append(f'Failed rfc822 attachment: {err}')
             else:
                 try:
                     attachment_meta = PayloadMeta(

--- a/smtp/smtp/smtp.stoq
+++ b/smtp/smtp/smtp.stoq
@@ -4,7 +4,7 @@ Module = smtp
 
 [Documentation]
 Author = Marcus LaFerrera
-Version = 2.0.2
+Version = 2.0.3
 Website = https://github.com/PUNCH-Cyber/stoq
 Description = SMTP Parser Worker
 


### PR DESCRIPTION
pyzmail does not appear to be maintained any longer. Moving to python core library for e-mail.