### PR TITLE
Fixed a copy paste error in decompress

### DIFF
--- a/decompress/decompress/decompress.py
+++ b/decompress/decompress/decompress.py
@@ -93,7 +93,7 @@ class Decompress(WorkerPlugin):
 
         if plugin_opts and 'maximum_size' in plugin_opts:
             self.maximum_size = int(plugin_opts['maximum_size'])
-        elif config.has_option('options', 'passwords'):
+        elif config.has_option('options', 'maximum_size'):
             self.maximum_size = int(config.get('options', 'maximum_size'))
         else:
             self.maximum_size = 50_000_000


### PR DESCRIPTION
The code responsible for getting the maximum_size configuration was checking whether the password configuration was set.
I assume it's due to copypasting the similar code for the password configuration just above.