### PR TITLE
bug fix w.r.t byte encoding

### DIFF
--- a/iocextract/iocextract/iocextract.py
+++ b/iocextract/iocextract/iocextract.py
@@ -130,7 +130,7 @@ class IOCExtract(WorkerPlugin):
                     if matches:
                         results[ioc] = list(set(matches))
         elif self.compiled_re[ioctype]:
-            matches = self.compiled_re[ioctype].findall(payload.content.decode())
+            matches = self.compiled_re[ioc].findall(''.join(chr(x) for x in payload.content))
             if matches:
                 results[ioctype] = list(set(matches))
 


### PR DESCRIPTION
the .decode() wasn't working properly in 3.7.1, so moved it to a method that works against my test set as well as should work fine between Python 2 and 3.