### PR TITLE
IOC Extract - Add error handling to decoding

### DIFF
--- a/iocextract/README.md
+++ b/iocextract/README.md
@@ -14,6 +14,11 @@ All options below may be set by:
 - [`stoq` command](https://stoq-framework.readthedocs.io/en/latest/gettingstarted.html#plugin-options)
 - [`Stoq` class](https://stoq-framework.readthedocs.io/en/latest/dev/core.html?highlight=plugin_opts#using-providers)
 
+#### Module performance
+
+The speed of the `UnicodeDammit` decoder from `BeautifulSoup` module is much faster when the `cchardet` module is installed,
+but will fall back to the `chardet` module if it is not installed.
+
 ### Options
 
 - `iana_tld_file` [str]: Path to IANA TLD file. If the file does not exist, `iocextract` will attempt to download the file from `iana_url`

--- a/iocextract/iocextract/iocextract.py
+++ b/iocextract/iocextract/iocextract.py
@@ -133,11 +133,11 @@ class IOCExtract(WorkerPlugin):
         if ioctype == 'all':
             for ioc in self.compiled_re:
                 if self.compiled_re[ioc]:
-                    matches = self.compiled_re[ioc].findall(payload.content.decode())
+                    matches = self.compiled_re[ioc].findall(payload.content.decode(errors='replace'))
                     if matches:
                         results[ioc] = list(set(matches))
         elif self.compiled_re[ioctype]:
-            matches = self.compiled_re[ioctype].findall(payload.content.decode())
+            matches = self.compiled_re[ioctype].findall(payload.content.decode(errors='replace'))
             if matches:
                 results[ioctype] = list(set(matches))
 

--- a/iocextract/iocextract/iocextract.py
+++ b/iocextract/iocextract/iocextract.py
@@ -30,6 +30,7 @@ from configparser import ConfigParser
 from typing import Dict, Set, Optional, List
 from ipaddress import ip_address, ip_network
 from inspect import currentframe, getframeinfo
+from bs4 import UnicodeDammit
 
 from stoq.plugins import WorkerPlugin
 from stoq.helpers import StoqConfigParser
@@ -133,11 +134,11 @@ class IOCExtract(WorkerPlugin):
         if ioctype == 'all':
             for ioc in self.compiled_re:
                 if self.compiled_re[ioc]:
-                    matches = self.compiled_re[ioc].findall(payload.content.decode(errors='replace'))
+                    matches = self.compiled_re[ioc].findall(UnicodeDammit(payload.content).unicode_markup)
                     if matches:
                         results[ioc] = list(set(matches))
         elif self.compiled_re[ioctype]:
-            matches = self.compiled_re[ioctype].findall(payload.content.decode(errors='replace'))
+            matches = self.compiled_re[ioctype].findall(UnicodeDammit(payload.content).unicode_markup)
             if matches:
                 results[ioctype] = list(set(matches))
 

--- a/iocextract/iocextract/iocextract.stoq
+++ b/iocextract/iocextract/iocextract.stoq
@@ -18,7 +18,7 @@ Module = iocextract
 
 [Documentation]
 Author = Mike Geide, Marcus LaFerrera
-Version = 3.0.1
+Version = 3.0.2
 Website = https://github.com/PUNCH-Cyber/stoq-plugins-public
 Description = Regex routines to extract and normalize IOC's from a payload
 

--- a/smtp/README.md
+++ b/smtp/README.md
@@ -14,6 +14,11 @@ All options below may be set by:
 - [`stoq` command](https://stoq-framework.readthedocs.io/en/latest/gettingstarted.html#plugin-options)
 - [`Stoq` class](https://stoq-framework.readthedocs.io/en/latest/dev/core.html?highlight=plugin_opts#using-providers)
 
+#### Module performance
+
+The speed of the `UnicodeDammit` decoder from `BeautifulSoup` module is much faster when the `cchardet` module is installed,
+but will fall back to the `chardet` module if it is not installed.
+
 ### Options
 
 - `omit_body` [`True`/`False`]: Save body of e-mail (text or html) to the results.

--- a/tnef/README.md
+++ b/tnef/README.md
@@ -9,3 +9,8 @@
 ## Configuration and Options
 
 No configuration options are required.
+
+#### Module performance
+
+The speed of the `UnicodeDammit` decoder from `BeautifulSoup` module is much faster when the `cchardet` module is installed,
+but will fall back to the `chardet` module if it is not installed.


### PR DESCRIPTION
If an invalid character is found, the decoding fails.
See issue https://github.com/PUNCH-Cyber/stoq-plugins-public/issues/90