### PR TITLE
WIP: Update to use pathlib

### DIFF
--- a/filedir/filedir/filedir.py
+++ b/filedir/filedir/filedir.py
@@ -59,7 +59,7 @@ class FileDirPlugin(ProviderPlugin, ConnectorPlugin, ArchiverPlugin):
         if not self.source_dir:
             raise StoqPluginException('Source directory not defined')
         source_path = Path(self.source_dir).resolve()
-        if source_path.is_dir:
+        if source_path.is_dir():
             if self.recursive:
                 for path in source_path.rglob('**/*'):
                     await self._queue(path, queue)


### PR DESCRIPTION
The first fix is for the incorrect use of is_dir in the filedir plugin. 

If desired, other uses of os.path can be replaced with uses of pathlib.