### PR TITLE
YARA asyncio Scanning 

### DIFF
--- a/yara/yarascan/rules/dispatcher.yar
+++ b/yara/yarascan/rules/dispatcher.yar
@@ -152,25 +152,13 @@ rule smtp_message
         save = "True"
     strings:
         $empty_line = { 0D 0A 0D 0A }
+        $empty_line_lf = { 0A 0A }  // Observed in files but not RFC compliant
         // Values required in the email header per RFC 5322 3.6
         $hdr_orig_date = /\nDate[ \t]{0,1000}:/ nocase
         $hdr_originator = /\nFrom[ \t]{0,1000}:/ nocase
     condition:
-        for all of ($hdr_*) : ( @[1] < @empty_line[1] )
+        for all of ($hdr_*) : (
+            @[1] < @empty_line[1] or
+            @[1] < @empty_line_lf[1]
+        )
 }
-
-/*
-rule smtp_message_invalid_line_ending
-{
-    meta:
-        plugin = "smtp"
-        save = "True"
-    strings:
-        $invalid_empty_line = { 0A 0A }  // Explicitly invalid according to all SMTP RFCs
-        // Values required in the email header per RFC 5322 3.6
-        $hdr_orig_date = /\nDate[ \t]{0,1000}:/ nocase
-        $hdr_originator = /\nFrom[ \t]{0,1000}:/ nocase
-    condition:
-        for all of ($hdr_*) : ( @[1] < @invalid_empty_line[1] )
-}
-*/

--- a/yara/yarascan/rules/dispatcher.yar
+++ b/yara/yarascan/rules/dispatcher.yar
@@ -158,3 +158,19 @@ rule smtp_message
     condition:
         for all of ($hdr_*) : ( @[1] < @empty_line[1] )
 }
+
+/*
+rule smtp_message_invalid_line_ending
+{
+    meta:
+        plugin = "smtp"
+        save = "True"
+    strings:
+        $invalid_empty_line = { 0A 0A }  // Explicitly invalid according to all SMTP RFCs
+        // Values required in the email header per RFC 5322 3.6
+        $hdr_orig_date = /\nDate[ \t]{0,1000}:/ nocase
+        $hdr_originator = /\nFrom[ \t]{0,1000}:/ nocase
+    condition:
+        for all of ($hdr_*) : ( @[1] < @invalid_empty_line[1] )
+}
+*/


### PR DESCRIPTION
The YARA match function is blocking, this pull wraps it in an event loop.

To test it, I used the following to simulate a slow YARA match.
```
    def _blocking_yara(self, rules, content):
        time.sleep(1)
        return rules.match(data=content, timeout=self.timeout)

```

Would it be better prefer to include a decorator in the stoq utils to replicate this behavior in situations where the plugin cannot be converted to support asyncio?  
```
def asyncio_task_executor(func, *, loop=None, executor=None):
    @functools.wraps(func)
    async def wrapper(*args, **kwargs):
        _loop = loop if loop is not None else asyncio.get_event_loop()
        return await _loop.run_in_executor(
            executor=executor,
            func=functools.partial(func, *args, **kwargs)
        )
    return wrapper
```