### PR TITLE
Fix build and add Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.6
   - 3.7
   - 3.8
+  - 3.9
 
 before_install:
   - sudo apt-get -yq install software-properties-common

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,12 @@ before_install:
   - sudo apt-get -yq install software-properties-common
   - sudo apt-add-repository -y multiverse
   - sudo apt-get -yq update
-  - sudo apt-get -yq install automake build-essential libyaml-dev libmagic-dev cython autoconf libffi-dev libfuzzy-dev unzip libimage-exiftool-perl
+  - sudo apt-get -yq install automake build-essential libyaml-dev libmagic-dev cython autoconf libffi-dev libfuzzy-dev unzip libimage-exiftool-perl swig
   - pip install stoq-framework
-  - wget -O /tmp/xorsearch.zip https://didierstevens.com/files/software/XORSearch_V1_11_3.zip
+  - wget -O /tmp/xorsearch.zip https://github.com/DidierStevens/FalsePositives/raw/master/XORSearch_V1_11_3.zip
   - unzip /tmp/xorsearch.zip -d /tmp
   - sudo gcc -o /usr/local/bin/xorsearch /tmp/XORSearch.c
-  - sed -i "s@bin_path = xorsearch@bin_path = /usr/local/bin/xorsearch@" /home/travis/build/PUNCH-Cyber/stoq-plugins-public/xorsearch/xorsearch/xorsearch.stoq
+  - sed -i "s@bin_path = xorsearch@bin_path = /usr/local/bin/xorsearch@" $(find . -name 'xorsearch.stoq')
 
 install:
   - pip install -r hash_ssdeep/requirements.txt


### PR DESCRIPTION
There are existing TravisCI build errors on the setup and installation of some dependencies. These changes address the build errors. They include:

- Install swig (needed to build M2Crypto dependency)
- Change URL of XORSearch V1.11.3 binary download
- Modify `xorsearch` path modification to work in other repos (not specifically PUNCH-Cyber's base repo)
- Add Python 3.9 as a build/test target