### PR TITLE
Update setup.py for hash_ssdeep to fix name error

### DIFF
--- a/hash_ssdeep/setup.py
+++ b/hash_ssdeep/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 setup(
-    name='ssdeep',
+    name='hash_ssdeep',
     version='3.0.0',
     author='Marcus LaFerrera (@mlaferrera)',
     url='https://github.com/PUNCH-Cyber/stoq-plugins-public',


### PR DESCRIPTION
package install name needs to match proposed name in install.

At present, when installing the hash_ssdeep plugin, the install command `stoq install --github stoq:hash_ssdeep` fails with:
```
Collecting hash_ssdeep
Cloning https://github.com/PUNCH-Cyber/stoq-plugins-public.git (to revision v3) to /private/var/folders/1z/rdthjbw52bb9wcvqf_4qv_rr0000gn/T/pip-install-0ccaaovu/hash-ssdeep_2627cd64df82459f94c93a4d403c2f84
Running command git clone -q https://github.com/PUNCH-Cyber/stoq-plugins-public.git /private/var/folders/1z/rdthjbw52bb9wcvqf_4qv_rr0000gn/T/pip-install-0ccaaovu/hash-ssdeep_2627cd64df82459f94c93a4d403c2f84
Running command git checkout -b v3 --track origin/v3
Switched to a new branch 'v3'
Branch 'v3' set up to track remote branch 'v3' from 'origin'.
WARNING: Generating metadata for package hash-ssdeep produced metadata for project name ssdeep. Fix your #egg=hash-ssdeep fragments.
WARNING: Discarding git+https://github.com/PUNCH-Cyber/stoq-plugins-public.git@v3#egg=hash_ssdeep&subdirectory=hash_ssdeep. Requested ssdeep from git+https://github.com/PUNCH-Cyber/stoq-plugins-public.git@v3#egg=hash_ssdeep&subdirectory=hash_ssdeep has inconsistent name: filename has 'hash-ssdeep', but metadata has 'ssdeep'
ERROR: Could not find a version that satisfies the requirement hash-ssdeep (unavailable) (from versions: none)
ERROR: No matching distribution found for hash-ssdeep (unavailable)
```